### PR TITLE
onMessageReceived accepts a second param in callback with user data from socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,25 @@
+# [2.1.0] - 2020-04-27  
+
+onMessageReceived method at DeepstreamMonitoring interface receives socket user data ({ userId, serverData, clientData }) as second param in callback
+
 # [2.0.2] - 2019-10-10
 # [2.0.1] - 2019-10-10
 
 Fixing publish issue due to a greedy import
 
 # [2.0.0] - 2019-10-10
-  
+
 Changing recieved to received
 
 Changing permission callback to be much less verbose
 Changing auth callback to return an object instead of a callback to allow multiple endpoints
 
 # [1.0.3] - 2019-08-09
-  
+
 Adding a metaObject for monitoring and logs
 
 # [1.0.2] - 2019-07-31
-  
+
 Removing dependency on ts-essentials. Plugins that depend on this package now also
 need to install @deepstream/protobuf as a dev dependency
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/types",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepstream/types",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "The types and enums used by plugins",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ export interface DeepstreamCache extends DeepstreamStorage  {
 export interface DeepstreamMonitoring extends DeepstreamPlugin  {
   onErrorLog (loglevel: LOG_LEVEL, event: EVENT, logMessage: string, metaData: MetaData): void
   onLogin (allowed: boolean, endpointType: string): void
-  onMessageReceived (message: Message): void
+  onMessageReceived (message: Message, socketUserData: JSONObject): void
   onMessageSend (message: Message): void
   onBroadcast (message: Message, count: number): void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,10 +237,15 @@ export interface DeepstreamCache extends DeepstreamStorage  {
   headBulk (recordNames: string[], callback: StorageHeadBulkCallback): void
 }
 
+export interface SocketUserData {
+  userId: string,
+  serverData: JSONObject | null
+}
+
 export interface DeepstreamMonitoring extends DeepstreamPlugin  {
   onErrorLog (loglevel: LOG_LEVEL, event: EVENT, logMessage: string, metaData: MetaData): void
   onLogin (allowed: boolean, endpointType: string): void
-  onMessageReceived (message: Message, socketUserData: JSONObject): void
+  onMessageReceived (message: Message, socketUserData: SocketUserData): void
   onMessageSend (message: Message): void
   onBroadcast (message: Message, count: number): void
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,15 @@ export abstract class Handler<SpecificMessage> {
   public async close (): Promise<void> {}
 }
 
-export interface SimpleSocketWrapper {
+export interface SocketData {
   socketType: string
   userId: string | null
   clientData: object | null
-  serverData: object | null
+  serverData: object | null,
   isRemote?: boolean
+}
+
+export interface SimpleSocketWrapper extends SocketData {
   parseMessage (serializedMessage: any): ParseResult[]
   sendMessage (message: Message, buffer?: boolean): void
   sendAckMessage (message: Message, buffer?: boolean): void
@@ -237,15 +240,10 @@ export interface DeepstreamCache extends DeepstreamStorage  {
   headBulk (recordNames: string[], callback: StorageHeadBulkCallback): void
 }
 
-export interface SocketUserData {
-  userId: string,
-  serverData: JSONObject | null
-}
-
 export interface DeepstreamMonitoring extends DeepstreamPlugin  {
   onErrorLog (loglevel: LOG_LEVEL, event: EVENT, logMessage: string, metaData: MetaData): void
   onLogin (allowed: boolean, endpointType: string): void
-  onMessageReceived (message: Message, socketUserData: SocketUserData): void
+  onMessageReceived (message: Message, socketData: SocketData): void
   onMessageSend (message: Message): void
   onBroadcast (message: Message, count: number): void
 }


### PR DESCRIPTION
The goal is to be able to monitor not only messages, but also user actions, useful when implementing a custom monitoring plugin for an audit log in order to know which user did what based on messages received by the server. The idea is to extract from the socketWrapper the `{ userId, serverData, clientData }` information to make it available for the custom monitoring plugin

This pull request implements only the interface description. If approved, the other pull requests will be made in order to update the messageDistributor at server repo and example plugins.